### PR TITLE
Changed msg type from string to interface

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -83,11 +83,11 @@ type Logger interface {
 	SetHandler(h Handler)
 
 	// Log a message at the given level with context key/value pairs
-	Debug(msg string, ctx ...interface{})
-	Info(msg string, ctx ...interface{})
-	Warn(msg string, ctx ...interface{})
-	Error(msg string, ctx ...interface{})
-	Crit(msg string, ctx ...interface{})
+	Debug(msg interface{}, ctx ...interface{})
+	Info(msg interface{}, ctx ...interface{})
+	Warn(msg interface{}, ctx ...interface{})
+	Error(msg interface{}, ctx ...interface{})
+	Crit(msg interface{}, ctx ...interface{})
 }
 
 type logger struct {
@@ -125,24 +125,24 @@ func newContext(prefix []interface{}, suffix []interface{}) []interface{} {
 	return newCtx
 }
 
-func (l *logger) Debug(msg string, ctx ...interface{}) {
-	l.write(msg, LvlDebug, ctx)
+func (l *logger) Debug(msg interface{}, ctx ...interface{}) {
+	l.write(fmt.Sprint(msg), LvlDebug, ctx)
 }
 
-func (l *logger) Info(msg string, ctx ...interface{}) {
-	l.write(msg, LvlInfo, ctx)
+func (l *logger) Info(msg interface{}, ctx ...interface{}) {
+	l.write(fmt.Sprint(msg), LvlInfo, ctx)
 }
 
-func (l *logger) Warn(msg string, ctx ...interface{}) {
-	l.write(msg, LvlWarn, ctx)
+func (l *logger) Warn(msg interface{}, ctx ...interface{}) {
+	l.write(fmt.Sprint(msg), LvlWarn, ctx)
 }
 
-func (l *logger) Error(msg string, ctx ...interface{}) {
-	l.write(msg, LvlError, ctx)
+func (l *logger) Error(msg interface{}, ctx ...interface{}) {
+	l.write(fmt.Sprint(msg), LvlError, ctx)
 }
 
-func (l *logger) Crit(msg string, ctx ...interface{}) {
-	l.write(msg, LvlCrit, ctx)
+func (l *logger) Crit(msg interface{}, ctx ...interface{}) {
+	l.write(fmt.Sprint(msg), LvlCrit, ctx)
 }
 
 func (l *logger) SetHandler(h Handler) {

--- a/root.go
+++ b/root.go
@@ -1,6 +1,7 @@
 package log15
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/inconshreveable/log15/term"
@@ -42,26 +43,26 @@ func Root() Logger {
 // runtime.Caller(2) always refers to the call site in client code.
 
 // Debug is a convenient alias for Root().Debug
-func Debug(msg string, ctx ...interface{}) {
-	root.write(msg, LvlDebug, ctx)
+func Debug(msg interface{}, ctx ...interface{}) {
+	root.write(fmt.Sprint(msg), LvlDebug, ctx)
 }
 
 // Info is a convenient alias for Root().Info
-func Info(msg string, ctx ...interface{}) {
-	root.write(msg, LvlInfo, ctx)
+func Info(msg interface{}, ctx ...interface{}) {
+	root.write(fmt.Sprint(msg), LvlInfo, ctx)
 }
 
 // Warn is a convenient alias for Root().Warn
-func Warn(msg string, ctx ...interface{}) {
-	root.write(msg, LvlWarn, ctx)
+func Warn(msg interface{}, ctx ...interface{}) {
+	root.write(fmt.Sprint(msg), LvlWarn, ctx)
 }
 
 // Error is a convenient alias for Root().Error
-func Error(msg string, ctx ...interface{}) {
-	root.write(msg, LvlError, ctx)
+func Error(msg interface{}, ctx ...interface{}) {
+	root.write(fmt.Sprint(msg), LvlError, ctx)
 }
 
 // Crit is a convenient alias for Root().Crit
-func Crit(msg string, ctx ...interface{}) {
-	root.write(msg, LvlCrit, ctx)
+func Crit(msg interface{}, ctx ...interface{}) {
+	root.write(fmt.Sprint(msg), LvlCrit, ctx)
 }


### PR DESCRIPTION
To keep consistent with the stdlog I changed
the public api from `msg string` to `msg interface{}`
and used fmt.Sprint to pass a string to the private
`write` method.